### PR TITLE
Merge branch mkiso-hfs+

### DIFF
--- a/mkiso
+++ b/mkiso
@@ -151,5 +151,5 @@ xorriso -as mkisofs \
         -hfsplus \
         -hfsplus-serial-no fc4d1567781ece66 \
         -hfsplus-block-size 512 \
-        -apm-block-size 512 \
+        -apm-block-size 512
 

--- a/mkiso
+++ b/mkiso
@@ -149,7 +149,7 @@ xorriso -as mkisofs \
         $bios_opts \
         $uefi_opts \
         -hfsplus \
-        -hfsplus-serial-no i5t7n5k2l1u6u5r8 \
+        -hfsplus-serial-no fc4d1567781ece66 \
         -hfsplus-block-size 512 \
         -apm-block-size 512 \
-        
+

--- a/mkiso
+++ b/mkiso
@@ -147,4 +147,9 @@ xorriso -as mkisofs \
         -o "$output" \
         "$iso_dir" \
         $bios_opts \
-        $uefi_opts
+        $uefi_opts \
+        -hfsplus \
+        -hfsplus-serial-no i5t7n5k2l1u6u5r8 \
+        -hfsplus-block-size 512 \
+        -apm-block-size 512 \
+        

--- a/mkiso
+++ b/mkiso
@@ -133,7 +133,7 @@ test "$uefi" = y && {
         -no-emul-boot
         -e efi.img
         -graft-points efi.img=$iso_dir/efi.img
-        -append_partition 2 0xef $iso_dir/efi.img
+        -append_partition 1 0xef $iso_dir/efi.img
     "
 }
 


### PR DESCRIPTION
- Changed the partition to which the EFI image is embedded; this fixes a problem with ISO files generated using `mkiso` not booting on Mac computers. ISO files now boot on both PC and Mac.
- Added options to `xorriso` for adding HFS+ filesystem inside the ISO 9660 image.